### PR TITLE
chore(efa): do not schedule new DS EFA on previous efa nodes

### DIFF
--- a/manifests/state-driver/0500_efa_daemonset.yaml
+++ b/manifests/state-driver/0500_efa_daemonset.yaml
@@ -29,6 +29,13 @@ spec:
       nodeSelector:
         nvidia.com/gpu.deploy.efa-driver: "true"
         feature.node.kubernetes.io/kernel-version.full: {{ .Precompiled.KernelVersion | quote }} # EFA is ONLY precompiled
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: aws-efa-driver-ready
+                operator: DoesNotExist
       containers:
       - name: efa-installer
         image: {{ .EFA.ImagePath }}


### PR DESCRIPTION
On `staging` we observed that the label `nvidia.com/gpu.deploy.efa-driver` is added on ALL nodes.

The NEW EFA installer `rmmod` the efa driver and the `modprobe` it.

To avoid disrupting currently running workloads, we should not schedule the new EFA DS installer onto current nodes. These nodes have the `aws-efa-driver-ready` label.

This PR modifies the DS to not schedule on nodes with `aws-efa-driver-ready` label.