### PR TITLE
feat(driver): set hostNetwork: true for driver daemonset

### DIFF
--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -98,6 +98,7 @@ spec:
       priorityClassName: {{ default "system-node-critical" .Driver.Spec.PriorityClassName }}
       serviceAccountName: {{ .Driver.Name }}
       hostPID: true
+      hostNetwork: true
       # Add any configured pull secrets
       {{- if any .Driver.Spec.ImagePullSecrets .Driver.Spec.Manager.ImagePullSecrets (and .GDS .GDS.Spec.ImagePullSecrets) (and .GDRCopy .GDRCopy.Spec.ImagePullSecrets) }}
       imagePullSecrets:


### PR DESCRIPTION
### Description

This PR sets the `hostNetwork: true` for the nvidia-gpu-driver pod. It is required for `nvidia-gridd` to access IMDS on Azure to get driver license.

### Testing

On arbok.us3.staging.dog:
- [x] Check with `nvidia-smi -q | grep License` that License is successfully retrieved from IMDS service.
- [x] Run basic `/cuda-samples/vectorAdd` test.
- [x] Deploy piioner service and run performance test to make sure node managed by gpu-operator has the same performance as node with custom AMI (not managed by gpu-operator)


### Breadcrumbs
Jira: [NODES-487](https://datadoghq.atlassian.net/browse/NODES-487)
Related PR: https://github.com/DataDog/gpu-driver-container/pull/10

[NODES-487]: https://datadoghq.atlassian.net/browse/NODES-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ